### PR TITLE
[FEAT] #32 유저 정보 목록 API 기능 구현

### DIFF
--- a/src/main/java/ai/Mayi/apiPayload/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/ai/Mayi/apiPayload/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package ai.Mayi.apiPayload.exception.handler;
+
+import ai.Mayi.apiPayload.exception.GeneralException;
+import ai.Mayi.apiPayload.code.ErrorReasonDTO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<ErrorReasonDTO> handleGeneralException(GeneralException ex) {
+        return new ResponseEntity<>(ex.getErrorReasonHttpStatus(), ex.getErrorReasonHttpStatus().getHttpStatus());
+    }
+}

--- a/src/main/java/ai/Mayi/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/ai/Mayi/jwt/JwtAuthenticationFilter.java
@@ -1,18 +1,15 @@
 package ai.Mayi.jwt;
 
 import ai.Mayi.apiPayload.code.status.ErrorStatus;
-import ai.Mayi.apiPayload.exception.handler.JwtHandler;
 import ai.Mayi.domain.User;
 import ai.Mayi.repository.UserRepository;
 import ai.Mayi.service.MyUserDetailsService;
-import ai.Mayi.web.dto.JwtTokenDTO;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Bean;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -82,16 +79,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         chain.doFilter(request, response);
     }
 
-//    @Override
-//    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-//        String path = request.getRequestURI();
-//        return path.startsWith("/user/register") || path.startsWith("/user/login");
-//    }
-
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
-        return !path.startsWith("/user/test"); // "/user/test"만 필터 적용, 나머지는 제외
+        return !path.startsWith("/user/data"); // "/user/test"만 필터 적용, 나머지는 제외
     }
 
     private void sendTokenResponse(HttpServletResponse response, String accessToken) {

--- a/src/main/java/ai/Mayi/jwt/JwtUtil.java
+++ b/src/main/java/ai/Mayi/jwt/JwtUtil.java
@@ -4,14 +4,12 @@ import javax.crypto.SecretKey;
 
 import ai.Mayi.apiPayload.code.status.ErrorStatus;
 import ai.Mayi.apiPayload.exception.handler.JwtHandler;
-import ai.Mayi.apiPayload.exception.handler.UserHandler;
 import ai.Mayi.domain.User;
 import ai.Mayi.repository.UserRepository;
 import ai.Mayi.web.dto.JwtTokenDTO;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -122,8 +120,8 @@ public class JwtUtil {
                     .build()
                     .parseSignedClaims(accessToken)
                     .getPayload();
-        } catch (ExpiredJwtException e) {
-            log.error("parseClaims 메서드 예외 처리");
+        } catch (Exception e) {
+            log.error("로그인 다시 하기");
             throw new JwtHandler(ErrorStatus._INVALID_JWT);
         }
     }

--- a/src/main/java/ai/Mayi/service/UserServiceImpl.java
+++ b/src/main/java/ai/Mayi/service/UserServiceImpl.java
@@ -6,6 +6,7 @@ import ai.Mayi.domain.User;
 import ai.Mayi.jwt.CookieUtil;
 import ai.Mayi.jwt.JwtUtil;
 import ai.Mayi.repository.UserRepository;
+import ai.Mayi.web.dto.CommonDTO;
 import ai.Mayi.web.dto.JwtTokenDTO;
 import ai.Mayi.web.dto.TokenDTO;
 import ai.Mayi.web.dto.UserDTO;
@@ -33,7 +34,7 @@ public class UserServiceImpl implements UserService {
     private final JwtUtil jwtUtil;
     private final TokenService tokenService;
 
-    public void signUp(UserDTO.JoinRequestDTO joinDto) {
+    public CommonDTO.IsSuccessDTO signUp(UserDTO.JoinRequestDTO joinDto) {
 
         var result = userRepository.findByUserEmail(joinDto.getUserEmail());
         if (result.isPresent()) {
@@ -54,6 +55,10 @@ public class UserServiceImpl implements UserService {
                 .build();
 
         userRepository.save(user);
+
+        return CommonDTO.IsSuccessDTO.builder()
+                .isSuccess(true)
+                .build();
     }
 
     public User findUserById(Long userId){

--- a/src/main/java/ai/Mayi/service/UserServiceImpl.java
+++ b/src/main/java/ai/Mayi/service/UserServiceImpl.java
@@ -7,6 +7,7 @@ import ai.Mayi.jwt.CookieUtil;
 import ai.Mayi.jwt.JwtUtil;
 import ai.Mayi.repository.UserRepository;
 import ai.Mayi.web.dto.JwtTokenDTO;
+import ai.Mayi.web.dto.TokenDTO;
 import ai.Mayi.web.dto.UserDTO;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
@@ -29,6 +30,8 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtUtil jwtUtil;
+    private final TokenService tokenService;
 
     public void signUp(UserDTO.JoinRequestDTO joinDto) {
 
@@ -90,6 +93,20 @@ public class UserServiceImpl implements UserService {
     public void loginOut(HttpServletResponse response) {
         CookieUtil.addCookie(response, "accessToken", null, 0);
         CookieUtil.addCookie(response, "refreshToken", null, 0);
+    }
+
+    public UserDTO.UserDataResponseDTO sendUserData(String accessToken){
+        String userEmail = jwtUtil.getUserEmail(accessToken);
+        Optional<User> userOpt = userRepository.findByUserEmail(userEmail);
+        User user = userOpt.orElseThrow(() -> new UserHandler(ErrorStatus._NOT_EXIST_USER));
+        //토큰 서비스 불러서 저장하기
+        TokenDTO.getTokenResDto aiToken = tokenService.getToken(user.getUserId());
+
+        return UserDTO.UserDataResponseDTO.builder()
+                .userEmail(user.getUserEmail())
+                .userName(user.getUsername())
+                .tokenList(aiToken.getTokenList())
+                .build();
     }
 
 

--- a/src/main/java/ai/Mayi/web/controller/UserController.java
+++ b/src/main/java/ai/Mayi/web/controller/UserController.java
@@ -2,6 +2,7 @@ package ai.Mayi.web.controller;
 import ai.Mayi.apiPayload.ApiResponse;
 import ai.Mayi.jwt.CookieUtil;
 import ai.Mayi.service.UserServiceImpl;
+import ai.Mayi.web.dto.CommonDTO;
 import ai.Mayi.web.dto.UserDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
@@ -34,13 +35,11 @@ public class UserController {
 
     @PostMapping("/register")
     @Operation(summary = "회원가입 API")
-    public ApiResponse<String> userRegister(@RequestBody UserDTO.JoinRequestDTO joinDto) {
+    public ApiResponse<CommonDTO.IsSuccessDTO> userRegister(@RequestBody UserDTO.JoinRequestDTO joinDto) {
 
         log.info("Registering post user: {}", joinDto.toString());
 
-        userserviceImpl.signUp(joinDto);
-
-        return ApiResponse.onSuccess("회원가입이 완료되었습니다.");
+        return ApiResponse.onSuccess(userserviceImpl.signUp(joinDto));
     }
 
     @GetMapping("/data")

--- a/src/main/java/ai/Mayi/web/controller/UserController.java
+++ b/src/main/java/ai/Mayi/web/controller/UserController.java
@@ -1,8 +1,10 @@
 package ai.Mayi.web.controller;
 import ai.Mayi.apiPayload.ApiResponse;
+import ai.Mayi.jwt.CookieUtil;
 import ai.Mayi.service.UserServiceImpl;
 import ai.Mayi.web.dto.UserDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,12 +34,19 @@ public class UserController {
 
     @PostMapping("/register")
     @Operation(summary = "회원가입 API")
-    public ApiResponse<String> user_register(@RequestBody UserDTO.JoinRequestDTO joinDto) {
+    public ApiResponse<String> userRegister(@RequestBody UserDTO.JoinRequestDTO joinDto) {
 
         log.info("Registering post user: {}", joinDto.toString());
 
         userserviceImpl.signUp(joinDto);
 
         return ApiResponse.onSuccess("회원가입이 완료되었습니다.");
+    }
+
+    @GetMapping("/data")
+    @Operation(summary = "유저정보 조회 API")
+    public ApiResponse<UserDTO.UserDataResponseDTO> userDataList (HttpServletRequest request) {
+        String accessToken = CookieUtil.getCookieValue(request, "accessToken");
+        return ApiResponse.onSuccess(userserviceImpl.sendUserData(accessToken));
     }
 }

--- a/src/main/java/ai/Mayi/web/dto/UserDTO.java
+++ b/src/main/java/ai/Mayi/web/dto/UserDTO.java
@@ -3,6 +3,8 @@ package ai.Mayi.web.dto;
 import lombok.*;
 import org.antlr.v4.runtime.misc.NotNull;
 
+import java.util.List;
+
 public class UserDTO {
 
     @Builder
@@ -45,8 +47,9 @@ public class UserDTO {
     @Setter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class LoginResponseDTO {
-        private Long userId;
+    public static class UserDataResponseDTO {
+        private String userEmail;
+        private String userName;
+        private List<TokenDTO.tokenDto> tokenList;
     }
-
 }

--- a/src/main/java/ai/Mayi/web/dto/UserDTO.java
+++ b/src/main/java/ai/Mayi/web/dto/UserDTO.java
@@ -25,15 +25,6 @@ public class UserDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class JoinResponseDTO {
-        private Long userId;
-        private String userEmail;
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
     public static class LoginRequestDTO {
         @NotNull
         private String userEmail;


### PR DESCRIPTION
## 관련 이슈
- close #32

## 개요
유저정보 조회 기능에 유저가 저장한 토큰 값을 포함하여 API 구현

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 리뷰 요구사항(선택)

## 유저정보 목록 조회 

### 실패
- JWT 토큰 값이 유효하지 않거나 없을경우 필터에서 검사한다.
- 현재 경우는 accessToken이 없고, refreshToken이 변조되었을 경우.

![image](https://github.com/user-attachments/assets/442bf73b-aa3e-416c-9d38-312d4dd4916b)


### 성공
![유저정보조회 ai 토큰 성공적으로 반환](https://github.com/user-attachments/assets/db1363a1-b264-4dbb-8be8-026f0945a61f)

### AI 토큰이 저장되어있지 않은 유저의 경우
![유저정보 조회 ai 토큰 없을때](https://github.com/user-attachments/assets/9ed35347-c4fd-4d90-83b8-6db5175c8d18)